### PR TITLE
Add PSR-20 clock implementation declaration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,9 @@
         "sanmai/phpstan-rules": "^0.3.1",
         "vimeo/psalm": "^6.12"
     },
+    "provide": {
+        "psr/clock-implementation": "1.0"
+    },
     "autoload": {
         "psr-4": {
             "DuoClock\\": "src/"


### PR DESCRIPTION
Declares that DuoClock provides psr/clock-implementation to help package managers identify this as a PSR-20 compatible clock.